### PR TITLE
Fix Strapi documentation link formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,7 @@ The frontend communicates with Strapi through the API layer in `src/lib/`. The m
 
 - [Live Demo](https://your-portfolio-url.com)
 - [Backend Repository](https://github.com/your-username/portfolio-backend)
-- [Strapi Documentation
-  ](https://docs.strapi.io/)
+- [Strapi Documentation](https://docs.strapi.io/)
 
 ---
 


### PR DESCRIPTION
## Summary
- fix Strapi documentation link in README so markdown renders correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars in existing source files)*
- `npx eslint README.md` *(warns: File ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68ab80b5d53c8328a5659ad63648057a