### PR TITLE
docs: update lib readme to reflect missing hooks

### DIFF
--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -24,10 +24,9 @@ Portfolio-specific API functions for fetching data from your content types.
 ### `strapi-utils.ts`
 
 Utility functions for processing and transforming Strapi data.
+### Hooks (planned)
 
-### `hooks/useStrapiData.ts`
-
-React hooks for fetching data with loading states and error handling.
+TODO: React hooks for Strapi data fetching will live in `src/lib/hooks` once implemented.
 
 ### `types/strapi.ts`
 
@@ -89,27 +88,9 @@ const projectsByTag = await portfolioApi.getProjectsByTag(tagId);
 const tags = await portfolioApi.getAllTags();
 ```
 
-### Using React hooks
+### Using React hooks (planned)
 
-```typescript
-import { useHomePage, useProjects, useTags } from '@/lib/hooks/useStrapiData';
-
-function MyComponent() {
-  const { data: homePage, loading, error } = useHomePage();
-  const { data: projects } = useProjects();
-  const { data: tags } = useTags();
-
-  if (loading) return <div>Loading...</div>;
-  if (error) return <div>Error: {error}</div>;
-
-  return (
-    <div>
-      <h1>{homePage?.introduction}</h1>
-      {/* Render your data */}
-    </div>
-  );
-}
-```
+TODO: Add examples for React hooks once they are implemented.
 
 ### Using utility functions
 


### PR DESCRIPTION
## Summary
- remove outdated reference to hooks/useStrapiData
- add placeholder notes for planned React hooks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: unused variables in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68ab80b79de88328bafd1e82c3f50375